### PR TITLE
Universal Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Assume FDP_CONFIG_DIR, storage_locations and objects have been set by CLI tool
 import os
 import fairdatapipeline as pipeline
 
-token = os.environ.get('FDP_LOCAL_TOKEN')
-config_path = os.environ.get('FDP_CONFIG_DIR') + '/config.yaml'
-script_path = os.environ.get('FDP_CONFIG_DIR') + '/script.sh'
+token = os.environ['FDP_LOCAL_TOKEN']
+config_dir = os.environ['FDP_CONFIG_DIR']
+config_path = os.path.join(config_dir, 'config.yaml')
+script_path = os.path.join(config_dir, 'script.sh')
 
 handle = pipeline.initialise(token, config_path, script_path)
 


### PR DESCRIPTION
Uses `os.path.join` for the example to handle both Windows and UNIX cases, also uses direct dictionary access.