### PR TITLE
added wildcard search for a given endpoint and key

### DIFF
--- a/fairdatapipeline/__init__.py
+++ b/fairdatapipeline/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "link_read",
     "link_write",
     "finalise",
+    "search",
     "raise_issue_by_data_product",
     "raise_issue_by_index",
     "raise_issue_with_config",
@@ -15,7 +16,7 @@ __all__ = [
 
 from .fdp_utils import get_handle_index_from_path
 from .link import link_read, link_write
-from .pipeline import finalise, initialise
+from .pipeline import finalise, initialise, search
 from .raise_issue import (
     raise_issue_by_data_product,
     raise_issue_by_existing_data_product,

--- a/tests/ext/find_csv.yaml
+++ b/tests/ext/find_csv.yaml
@@ -1,0 +1,20 @@
+run_metadata:
+  description: Write csv file
+  local_data_registry_url: http://127.0.0.1:8000/api/
+  remote_data_registry_url: https://data.scrc.uk/api/
+  default_input_namespace: testing
+  default_output_namespace: testing
+  write_data_store: tmp
+  local_repo: ./
+  script: |-
+        python3 py.test
+  public: true
+  latest_commit: 221bfe8b52bbfb3b2dbdc23037b7dd94b49aaa70
+  remote_repo: https://github.com/FAIRDataPipeline/pyDataPipeline
+
+write:
+- data_product: find/csv
+  description: test csv to test find data products
+  file_type: csv
+  use:
+    version: 0.0.1


### PR DESCRIPTION

created function inside pipeline  allows user to search using a wildcard

given an endpoint, a key and a wildcard
will find the items whose key contains the wildcard

tested by adding a new test file inside tests/ext , adding it to the registry and then running the function.

@RyanJField  please have a look 
at
pipeline.search
and
tests/test_raise_issue.py::test_find_data_product

 and please tell me if this is what you and @richardreeve  intended.

if ok, please merge 